### PR TITLE
Add Flask frontend and task API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastAPI Simple Test
 
-This project is a minimal FastAPI application demonstrating:
+This project is a minimal **FastAPI** API accompanied by a **Flask** front-end. The API demonstrates:
 
 - JWT authentication
 - User management with SQLAlchemy
@@ -9,6 +9,8 @@ This project is a minimal FastAPI application demonstrating:
 - Modular architecture (models, routers, services)
 - Automatic OpenAPI documentation
 - Pytest tests
+
+The Flask application renders HTML templates (using Jinja2, TailwindCSS and JavaScript) that consume the FastAPI service via HTTP calls.
 
 ## Installation
 
@@ -21,6 +23,16 @@ pip install -r requirements.txt
 ```bash
 uvicorn app.main:app --reload
 ```
+
+### Running the Flask Front-end
+
+Set the environment variable `FASTAPI_URL` to the URL where the FastAPI app is running (default `http://localhost:8000`). Then start the Flask development server:
+
+```bash
+python -m frontend.app
+```
+
+Open `http://localhost:5000` in your browser to see the cyberpunk task board.
 
 The API documentation will be available at `http://localhost:8000/docs`.
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,15 +2,25 @@
 
 # FastAPI provides the web framework used throughout the project
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 # Import routers that expose authentication and item related endpoints
-from .routers import auth, items
+from .routers import auth, items, tasks
 
 # Database metadata and engine are required to create tables on startup
 from .database import Base, engine
 
 # Create the FastAPI application instance
 app = FastAPI()
+
+# Allow cross-origin requests so the Flask frontend can reach the API
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.on_event("startup")
@@ -21,6 +31,7 @@ def on_startup() -> None:
 # Register API routers for authentication and item resources
 app.include_router(auth.router)
 app.include_router(items.router)
+app.include_router(tasks.router)
 
 
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,4 +3,5 @@
 # Currently only the ``User`` model exists, but additional models could be
 # added here in the future for convenience of importing.
 from .user import User
+from .task import Task
 

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String
+
+from ..database import Base
+
+class Task(Base):
+    """Simple task model used for demo purposes."""
+
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    description = Column(String, nullable=True)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,8 +1,8 @@
 """Expose the different API routers used by the application."""
 
 # Individual router modules implementing API endpoints
-from . import auth, items
+from . import auth, items, tasks
 
 # Allow ``from app.routers import auth`` style imports
-__all__ = ["auth", "items"]
+__all__ = ["auth", "items", "tasks"]
 

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,0 +1,27 @@
+"""Routes to manage Task resources."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..services import auth_service, task_service
+from .. import schemas
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+@router.get("/", response_model=list[schemas.TaskRead])
+def list_tasks(db: Session = Depends(auth_service.get_db)):
+    return task_service.get_tasks(db)
+
+
+@router.post("/", response_model=schemas.TaskRead)
+def create_task(task: schemas.TaskCreate, db: Session = Depends(auth_service.get_db)):
+    return task_service.create_task(db, task)
+
+
+@router.delete("/{task_id}", status_code=204)
+def delete_task(task_id: int, db: Session = Depends(auth_service.get_db)):
+    task = task_service.delete_task(db, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return None

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,4 +1,5 @@
 """Expose pydantic schemas for external imports."""
 
 from .user import UserCreate, UserRead, Token
+from .task import TaskCreate, TaskRead
 

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class TaskBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskRead(TaskBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -7,6 +7,7 @@ from .auth_service import (
     authenticate_user,
     get_current_user,
 )
+from . import task_service
 
 __all__ = [
     "get_db",
@@ -14,5 +15,6 @@ __all__ = [
     "create_user",
     "authenticate_user",
     "get_current_user",
+    "task_service",
 ]
 

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -1,0 +1,25 @@
+"""Service functions to manage Task CRUD operations."""
+
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def get_tasks(db: Session):
+    return db.query(models.Task).all()
+
+
+def create_task(db: Session, task: schemas.TaskCreate):
+    db_task = models.Task(title=task.title, description=task.description)
+    db.add(db_task)
+    db.commit()
+    db.refresh(db_task)
+    return db_task
+
+
+def delete_task(db: Session, task_id: int):
+    task = db.query(models.Task).get(task_id)
+    if task:
+        db.delete(task)
+        db.commit()
+    return task

--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+
+def create_app():
+    app = Flask(__name__)
+
+    from .routes.main import bp as main_bp
+    app.register_blueprint(main_bp)
+
+    return app

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,6 @@
+from . import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend/routes/main.py
+++ b/frontend/routes/main.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+import os
+
+bp = Blueprint('main', __name__)
+
+
+@bp.route('/')
+def index():
+    """Render the main page with the base API URL."""
+    api_url = os.environ.get('FASTAPI_URL', 'http://localhost:8000')
+    return render_template('index.html', api_url=api_url)

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -1,0 +1,24 @@
+body {
+    background-color: #0a0a0a;
+    color: #f1f1f1;
+    font-family: 'Orbitron', sans-serif;
+}
+
+.neon {
+    color: #39ff14;
+}
+
+.card {
+    background-color: #1a1a1a;
+    border: 1px solid #333;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 0 10px #39ff14;
+}
+
+.button-primary {
+    background-color: #ff007f;
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+}

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -1,0 +1,59 @@
+async function loadTasks() {
+    const apiUrl = document.body.dataset.api;
+    const response = await fetch(`${apiUrl}/tasks/`);
+    const data = await response.json();
+    const container = document.getElementById('tasks');
+    container.innerHTML = '';
+    data.forEach(task => {
+        const card = document.createElement('div');
+        card.className = 'card mb-4';
+        card.innerHTML = `
+            <h3 class="text-xl neon">${task.title}</h3>
+            <p>${task.description || ''}</p>
+            <button class="button-primary mt-2" onclick="deleteTask(${task.id})">Delete</button>
+        `;
+        container.appendChild(card);
+    });
+}
+
+async function createTask(evt) {
+    evt.preventDefault();
+    const apiUrl = document.body.dataset.api;
+    const title = document.getElementById('title').value;
+    const description = document.getElementById('description').value;
+    const response = await fetch(`${apiUrl}/tasks/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, description })
+    });
+    if (response.ok) {
+        notify('Task created');
+        loadTasks();
+        evt.target.reset();
+    } else {
+        notify('Error creating task');
+    }
+}
+
+async function deleteTask(id) {
+    const apiUrl = document.body.dataset.api;
+    const response = await fetch(`${apiUrl}/tasks/${id}`, { method: 'DELETE' });
+    if (response.status === 204) {
+        notify('Task deleted');
+        loadTasks();
+    } else {
+        notify('Error deleting task');
+    }
+}
+
+function notify(msg) {
+    const box = document.getElementById('notification');
+    box.textContent = msg;
+    box.classList.remove('hidden');
+    setTimeout(() => box.classList.add('hidden'), 2000);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('task-form').addEventListener('submit', createTask);
+    loadTasks();
+});

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -1,0 +1,12 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+<h1 class="text-3xl neon mb-4">Cyberpunk Task Board</h1>
+<div id="notification" class="hidden mb-4 p-2 bg-blue-800 text-white"></div>
+<form id="task-form" class="mb-6">
+    <input id="title" class="p-2 mr-2 text-black" placeholder="Title" required>
+    <input id="description" class="p-2 mr-2 text-black" placeholder="Description">
+    <button class="button-primary" type="submit">Add</button>
+</form>
+<div id="tasks" class="grid md:grid-cols-2 lg:grid-cols-3 gap-4"></div>
+{% endblock %}

--- a/frontend/templates/layout.html
+++ b/frontend/templates/layout.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cyberpunk Tasks</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+</head>
+<body data-api="{{ api_url }}" class="h-full">
+    <div class="container mx-auto p-4">
+        {% block content %}{% endblock %}
+    </div>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ passlib[bcrypt]
 python-jose
 pytest
 httpx
+Flask
+requests


### PR DESCRIPTION
## Summary
- introduce Task model and CRUD endpoints on FastAPI side
- enable CORS for FastAPI
- add Flask based frontend with Tailwind and cyberpunk theme
- include instructions for running frontend in README
- update requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68512cd250f883308ea50d209c270f90